### PR TITLE
refactor: Add astro-loading-indicator component to BaseHead.astro

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/react-dom": "^18.0.10",
     "astro": "^4.11.5",
     "astro-icon": "^0.8.0",
+    "astro-loading-indicator": "^0.5.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "prettier-plugin-organize-imports": "^3.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       astro-icon:
         specifier: ^0.8.0
         version: 0.8.1
+      astro-loading-indicator:
+        specifier: ^0.5.0
+        version: 0.5.0(astro@4.11.5(typescript@5.1.6))
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -2795,6 +2798,11 @@ packages:
 
   astro-icon@0.8.1:
     resolution: {integrity: sha512-APk+fbFnoyGdIVSPFrdrOW9YBK96/1fYuVe7ULTGW92+z00RKB8GfLJiUvzNVXUAX2rZJCFmruGVF4rrhcTYsg==}
+
+  astro-loading-indicator@0.5.0:
+    resolution: {integrity: sha512-NU06AzJEzvlzXLac8ODFgHjzTDyaF/GV+nQQ7Rq21rCeSifhmLQu219lJukIUS0ySs4ySO4PAwcaHGClOSEufA==}
+    peerDependencies:
+      astro: ^4.0.0
 
   astro@4.11.5:
     resolution: {integrity: sha512-TCRhuaLwrxwMhS8S1GG+ZTdrAXigX9C8E/YUTs/r2t+owHxDgwl86IV9xH1IHrCPoqhK6civyAQNOT+GKmkb0A==}
@@ -12127,6 +12135,10 @@ snapshots:
       node-fetch: 3.3.2
       resolve-pkg: 2.0.0
       svgo: 2.8.0
+
+  astro-loading-indicator@0.5.0(astro@4.11.5(typescript@5.1.6)):
+    dependencies:
+      astro: 4.11.5(typescript@5.1.6)
 
   astro@4.11.5(typescript@5.1.6):
     dependencies:

--- a/src/astro-components/BaseHead.astro
+++ b/src/astro-components/BaseHead.astro
@@ -1,5 +1,6 @@
 ---
 import { ViewTransitions } from "astro:transitions";
+import LoadingIndicator from "astro-loading-indicator/component";
 
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseHead /> component.
@@ -45,3 +46,4 @@ const { title, description, image = "/placeholder-social.jpg" } = Astro.props;
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
 
 <ViewTransitions />
+<LoadingIndicator color="black" height="3px" />


### PR DESCRIPTION
Update the BaseHead.astro file to import and include the astro-loading-indicator component. This change adds a loading indicator to the base head of the application, enhancing the user experience by providing visual feedback during page transitions.