### PR TITLE
refactor: Update BlogPost layout to use smaller calendar icon

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -30,8 +30,8 @@ const { frontmatter } = Astro.props;
         <div class="prose mx-auto md:prose-lg">
           <section>
             <h1>{frontmatter.title}</h1>
-            <div class="opacity-60 flex items-center gap-2">
-              <Icon name="uit:calender" class="text-secondary" size="18" />
+            <div class="flex items-center gap-2 text-base">
+              <Icon name="uit:calender" class="text-secondary" size="16" />
               {
                 frontmatter.updateDate ? (
                   <time datetime={frontmatter.updateDate.toISOString()}>


### PR DESCRIPTION
This commit updates the BlogPost layout in the src/layouts/BlogPost.astro file to use a smaller calendar icon. The previous icon size was too large and didn't align well with the text. By reducing the size of the calendar icon, the layout now looks more visually balanced and improves the overall design of the blog post page.